### PR TITLE
Strict type check in acceptable value

### DIFF
--- a/Enumeration/Enum.php
+++ b/Enumeration/Enum.php
@@ -78,7 +78,7 @@ abstract class Enum implements EnumInterface
      */
     public static function isAcceptableValue($value)
     {
-        return in_array($value, static::getPossibleValues());
+        return in_array($value, static::getPossibleValues(), true);
     }
 
     /**

--- a/Tests/Enumeration/EnumTest.php
+++ b/Tests/Enumeration/EnumTest.php
@@ -33,7 +33,15 @@ class EnumTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionIsRaisedWhenValueIsNotAcceptable()
     {
-        SimpleEnum::create(0);
+        SimpleEnum::create(3);
+    }
+
+    /**
+     * @expectedException \Biplane\EnumBundle\Exception\InvalidEnumArgumentException
+     */
+    public function testExceptionIsRaisedWhenValueIsNotAcceptableWithStrictCheck()
+    {
+        SimpleEnum::create('string');
     }
 
     public function testValueCanBeReadabled()

--- a/Tests/Fixtures/SimpleEnum.php
+++ b/Tests/Fixtures/SimpleEnum.php
@@ -6,12 +6,14 @@ use Biplane\EnumBundle\Enumeration\Enum;
 
 class SimpleEnum extends Enum
 {
+    const ZERO   = 0;
     const FIRST  = 1;
     const SECOND = 2;
 
     public static function getReadables()
     {
         return array(
+            self::ZERO => 'Zero',
             self::FIRST => 'First',
             self::SECOND => 'Second'
         );
@@ -19,6 +21,6 @@ class SimpleEnum extends Enum
 
     public static function getPossibleValues()
     {
-        return array(self::FIRST, self::SECOND);
+        return array(self::ZERO, self::FIRST, self::SECOND);
     }
 }


### PR DESCRIPTION
Лучше проверять еще и тип передаваемого значения при поиске в массиве возможных значений. Чтобы избежать нежелательных ситуаций когда `in_array('str', array(0)) === true`.
