### PR TITLE
configurable separator for ReadableFor and Readable

### DIFF
--- a/Enumeration/FlaggedEnum.php
+++ b/Enumeration/FlaggedEnum.php
@@ -46,12 +46,12 @@ abstract class FlaggedEnum extends Enum
      * Gets the human representation for a given value.
      *
      * @param mixed $value The value of a particular enumerated constant
-     *
+     * @param string $separator
      * @return string The human representation for a given value
      *
      * @throws InvalidEnumArgumentException When $value is not acceptable for this enumeration type
      */
-    public static function getReadableFor($value)
+    public static function getReadableFor($value, $separator = '; ')
     {
         if (!static::isAcceptableValue($value)) {
             throw new InvalidEnumArgumentException($value);
@@ -75,7 +75,7 @@ abstract class FlaggedEnum extends Enum
             }
         }
 
-        return implode('; ', $parts);
+        return implode($separator, $parts);
     }
 
     /**
@@ -142,6 +142,15 @@ abstract class FlaggedEnum extends Enum
         }
 
         return $mask;
+    }
+
+    /**
+     * @param string $separator
+     * @return string
+     */
+    public function getReadable($separator = '; ')
+    {
+        return static::getReadableFor($this->getValue(), $separator);
     }
 
     /**

--- a/Tests/Enumeration/FlaggedEnumTest.php
+++ b/Tests/Enumeration/FlaggedEnumTest.php
@@ -50,16 +50,29 @@ class FlaggedEnumTest extends \PHPUnit_Framework_TestCase
     public function testSingleFlagCanBeReadabled()
     {
         $this->assertEquals('First', FlagsEnum::getReadableFor(FlagsEnum::FIRST));
+        $instance = FlagsEnum::create(FlagsEnum::FIRST);
+        $this->assertEquals('First', $instance->getReadable());
     }
 
     public function testMultipleFlagsCanBeReadabled()
     {
         $this->assertEquals('First; Second', FlagsEnum::getReadableFor(FlagsEnum::FIRST | FlagsEnum::SECOND));
+        $instance = FlagsEnum::create(FlagsEnum::FIRST | FlagsEnum::SECOND);
+        $this->assertEquals('First; Second', $instance->getReadable());
     }
 
     public function testNoneCanBeReadabled()
     {
         $this->assertEquals('None', FlagsEnum::getReadableFor(FlagsEnum::NONE));
+        $instance = FlagsEnum::create(FlagsEnum::NONE);
+        $this->assertEquals('None', $instance->getReadable());
+    }
+
+    public function testReadableSeparatorCanBeChanged()
+    {
+        $this->assertEquals('First | Second', FlagsEnum::getReadableFor(FlagsEnum::FIRST | FlagsEnum::SECOND, ' | '));
+        $instance = FlagsEnum::create(FlagsEnum::FIRST | FlagsEnum::SECOND);
+        $this->assertEquals('First | Second', $instance->getReadable(' | '));
     }
 
     public function testAddFlags()


### PR DESCRIPTION
Changes to flagged-enum branch to permit using a separator different from the default '; '.
