### PR TITLE
Dropped Symfony < 3.4, Symfony 4 support

### DIFF
--- a/Serializer/Normalizer/EnumNormalizer.php
+++ b/Serializer/Normalizer/EnumNormalizer.php
@@ -5,15 +5,17 @@ namespace Biplane\EnumBundle\Serializer\Normalizer;
 use Biplane\EnumBundle\Enumeration\EnumInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
+use Symfony\Component\Serializer\SerializerAwareTrait;
 
 /**
  * EnumNormalizer
  *
  * @author Denis Vasilev <yethee@biplane.ru>
  */
-class EnumNormalizer extends SerializerAwareNormalizer implements NormalizerInterface, DenormalizerInterface
+class EnumNormalizer implements NormalizerInterface, DenormalizerInterface
 {
+    use SerializerAwareTrait;
+
     /**
      * Normalizes an object into a set of arrays/scalars
      *

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
 
     "require": {
         "php": ">=5.4",
-        "symfony/framework-bundle": "~2.7|~3.0",
-        "symfony/form": "~2.7|~3.0"
+        "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/form": "^3.4|^4.0"
     },
 
     "require-dev": {
-        "jms/serializer-bundle": "1.1.*",
-        "symfony/serializer": "~2.7|~3.0",
-        "phpunit/phpunit": "~4.8"
+        "jms/serializer-bundle": "^1.1",
+        "symfony/serializer": "^3.4|^4.0",
+        "phpunit/phpunit": "^4.8"
     },
 
     "suggest": {


### PR DESCRIPTION
Hi.

I got one project to maintain that uses your bundle.
Could you check this patch and release a new version supporting symfony 4?
I decided to drop older symfony version because serializer trait was introduced in 3.1 but all versions < 3.4 are not maintained anymore.

WDYT?